### PR TITLE
Fixed bug with size of sign message

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/Qt-AES"]
 	path = src/Qt-AES
-	url = git@github.com:QuasarApp/Qt-AES.git
+	url = https://github.com/QuasarApp/Qt-AES.git

--- a/Qt-Secret.pro
+++ b/Qt-Secret.pro
@@ -8,14 +8,12 @@
 TEMPLATE = subdirs
 CONFIG += ordered
 
-SUBDIRS +=  \
-        src \
-        tests \
-        qaesencryption
+SUBDIRS += src \
+           tests \
+           qaesencryption
 
 include($$PWD/test.pri)
 
 src.file = src/Qt-Secret.pro
 tests.file = tests/Qt-SecretTest.pro
 qaesencryption.file = src/Qt-AES/qaesencryption.pro
-

--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -363,6 +363,8 @@ bool QRSAEncryption::generatePairKey(QByteArray &pubKey,
                                      QByteArray &privKey,
                                      QRSAEncryption::Rsa rsa) {
 
+    qDebug() << "from forked" << endl;
+
     do {
 
         pubKey.clear();

--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -326,19 +326,10 @@ QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &p
         case RSA_64 / 4: {
             return decodeArray<uint64_t>(rawData, privKey);
         }
-<<<<<<< HEAD
 
         case RSA_128 / 4: {
             return decodeArray<uint128_t>(rawData, privKey);
         }
-
-=======
-
-        case RSA_128 / 4: {
-            return decodeArray<uint128_t>(rawData, privKey);
-        }
-
->>>>>>> 3f9ad7c6888202cffa30019e90b186cf988e82a7
         default: return QByteArray();
     }
 }
@@ -358,18 +349,21 @@ QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &pri
 // check valid EDS
 bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey) {
 
-    auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - QString(SIGN_MARKER).length() - 1),
-         signLength   = rawData.length() - signStartPos - QString(SIGN_MARKER).length() * 2;
+    // start position of SIGN_MARKER in rawData
+    auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - signMarkerLength - 1);
+
+    // length of signature in rawData
+    auto signLength   = rawData.length() - signStartPos - signMarkerLength * 2;
 
     // message, that was recieved from channel
     QByteArray message = rawData.left(signStartPos);
 
-    // signature, that was recieved and decrypt from channel
-    QByteArray signature = decode(QByteArray::fromHex(rawData.mid(signStartPos + QString(SIGN_MARKER).length(), signLength)),
-                                  pubKey);
+    // hash, that was decrypt from recieved signature
+    QByteArray recievedHash = decode(QByteArray::fromHex(rawData.mid(signStartPos + signMarkerLength, signLength)),
+                                     pubKey);
 
-    // if decrypt signature == sha256(recived message), then signed message is valid
-    return signature == QCryptographicHash::hash(message, QCryptographicHash::Sha256);
+    // if recievedHash == sha256(recived message), then signed message is valid
+    return recievedHash == QCryptographicHash::hash(message, QCryptographicHash::Sha256);
 }
 
 bool QRSAEncryption::generatePairKey(QByteArray &pubKey,

--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -101,15 +101,15 @@ INT randNumber() {
           % std::numeric_limits<int>::max());
 
     // сколько int укладывается в INT
-    // int longDiff = getBitsSize<INT>() / (sizeof (int) * 8);
+    int longDiff = getBitsSize<INT>() / (sizeof (int) * 8);
 
     INT res = 1;
-    //0100 0000
-    //1111 1111
 
-    do{
+    while(longDiff > 0){
+        longDiff--;
+
         res *= rand() % std::numeric_limits<int>::max();
-    }while(!(res & (static_cast<INT>(0x1) << (getBitsSize<INT>() - 1))));
+    }
 
     return res;
 }
@@ -162,6 +162,7 @@ INT toPrime(INT n) {
 // случайное простое число, не равное no
 template<class INT>
 INT randomPrimeNumber(INT no = 0) {
+
     srand(static_cast<unsigned int>(time(nullptr)));
 
     auto max = (~((INT(1)) << (getBitsSize<INT>() - 1))) >> ((getBitsSize<INT>()) >> 1);

--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -6,37 +6,26 @@
 //#
 
 #include "qrsaencryption.h"
-#include <QFile>
-#include <cmath>
-#include <QDebug>
-
-#include <QDateTime>
-#include <time.h>
 
 typedef unsigned __int128  uint128_t;
 typedef signed __int128  int128_t;
 
-// функция эйлера
 template<class INT>
 INT eulerFunc(const INT &p, const INT &q) {
     return (p - 1) * (q - 1);
 }
 
-// перемножение по моудлю
 template<class INT>
 INT mul(INT a, INT b, const INT &m) {
     INT res = 0;
     while (a != 0) {
-        // если a - нечетное
-        if (a & 1)
-            res = (res + b) % m;
+        if (a & 1) res = (res + b) % m;
         a >>= 1;
         b = (b << 1) % m;
     }
     return res;
 }
 
-// возведение в степень по модулю
 template<class INT>
 INT pows(const INT &a, const INT &b, const INT &m) {
     if(b == 0)
@@ -45,7 +34,7 @@ INT pows(const INT &a, const INT &b, const INT &m) {
         INT t = pows(a, b / 2, m);
         return mul(t , t, m) % m;
     }
-    return ( mul(pows(a, b - 1, m) , a, m) ) % m;
+    return ( mul(pows(a, b - 1, m), a, m)) % m;
 }
 
 template<class INT>
@@ -61,7 +50,6 @@ INT binpow (INT a, INT n, INT m) {
     return res % m;
 }
 
-// наибольший общий делитель, для взаимно простых == 1
 template<class INT>
 bool gcd(INT a, INT b) {
     INT c;
@@ -73,53 +61,45 @@ bool gcd(INT a, INT b) {
     return b;
 }
 
-// проверка на взаимную простоту
 template<class INT>
 bool isMutuallyPrime(INT a, INT b) {
     if (        (!(a % 2) && !(b % 2))
              || (!(a % 3) && !(b % 3))
              || (!(a % 5) && !(b % 5))
              || (!(a % 7) && !(b % 7))
-       ) {
-        return false;
-    }
+       ) return false;
 
     return gcd(a, b) == 1;
 }
 
-// количество бит в INT
 template<class INT>
 unsigned int getBitsSize() {
     return sizeof(INT) * 8;
 }
 
-// случайное число INT
 template<class INT>
 INT randNumber() {
     srand(std::chrono::duration_cast<std::chrono::nanoseconds>
           (std::chrono::system_clock::now().time_since_epoch()).count()
           % std::numeric_limits<int>::max());
 
-    // сколько int укладывается в INT
     int longDiff = getBitsSize<INT>() / (sizeof (int) * 8);
 
     INT res = 1;
 
-    while(longDiff > 0){
+    while (longDiff > 0) {
         longDiff--;
-
         res *= rand() % std::numeric_limits<int>::max();
     }
 
     return res;
 }
 
-// тест ферма
+// Ferma test
 template<class INT>
 bool isPrimeFerma(INT x){
 
-    if(x == 2)
-        return true;
+    if(x == 2) return true;
 
     for(int i = 0; i < 100; i++){
         INT a = (randNumber<INT>() % (x - 2)) + 2;
@@ -133,7 +113,7 @@ bool isPrimeFerma(INT x){
     return true;
 }
 
-// поиск ближайшего простого числа
+// return nearest prime number
 template<class INT>
 INT toPrime(INT n) {
 
@@ -145,26 +125,22 @@ INT toPrime(INT n) {
     INT RN = n;
 
     while (true) {
-        if (isPrimeFerma(LN)) {
-            return LN;
-        }
+
+        if (isPrimeFerma(LN)) return LN;
 
         RN+=2;
 
-        if (isPrimeFerma(RN)) {
-            return RN;
-        }
-
+        if (isPrimeFerma(RN)) return RN;
         LN-=2;
     }
 }
 
-// случайное простое число, не равное no
 template<class INT>
 INT randomPrimeNumber(INT no = 0) {
 
     srand(static_cast<unsigned int>(time(nullptr)));
 
+    // max INT
     auto max = (~((INT(1)) << (getBitsSize<INT>() - 1))) >> ((getBitsSize<INT>()) >> 1);
 
     auto p = toPrime(randNumber<INT>() % max);
@@ -214,7 +190,6 @@ INT fromArray(const QByteArray& array) {
     return res;
 }
 
-// генерация ключей
 template<class INT>
 bool keyGenerator(QByteArray &pubKey,
                   QByteArray &privKey) {
@@ -227,16 +202,13 @@ bool keyGenerator(QByteArray &pubKey,
         p = toPrime((p - 1) / 2);
     }
 
-    INT eilor = eulerFunc(p, q); // (p-1)*(q-1)
+    INT eilor = eulerFunc(p, q);
     INT e = randNumber<INT>() % eilor;
-
-    // d,e: d*e = 1 mod eilor
 
     if (!(e % 2)) e--;
 
     do {
         e -= 2;
-
     } while((!isMutuallyPrime(eilor, e)));
 
     INT d = ExtEuclid<INT>(eilor , e);;
@@ -253,7 +225,6 @@ bool keyGenerator(QByteArray &pubKey,
     return true;
 }
 
-// округляет в нижнюю сторону кол-во байт, отводимых под число i
 template< class INT>
 short getBytes(INT i) {
     return static_cast<short>(std::floor(log2(i) / 8));
@@ -319,15 +290,12 @@ QByteArray decodeArray(const QByteArray &rawData, const QByteArray &privKey) {
     return res.remove(res.lastIndexOf(ENDLINE), res.size());
 }
 
-// проверка ключей
 bool QRSAEncryption::testKeyPair(const QByteArray &pubKey, const QByteArray &privKey) {
     QByteArray tesVal = "Test message of encrypkey";
 
     bool result = tesVal == decode(encode(tesVal, pubKey), privKey);
 
-    if (!result) {
-        qWarning() << "(Warning): Testkey Fail, try generate new key pair!";
-    }
+    if (!result) qWarning() << "(Warning): Testkey Fail, try generate new key pair!";
 
     return result;
 }
@@ -339,45 +307,42 @@ QRSAEncryption::QRSAEncryption() {
 QByteArray QRSAEncryption::encode(const QByteArray &rawData, const QByteArray &pubKey) {
 
     switch (pubKey.size()) {
-    case RSA_64 / 4: {
-        return encodeArray<uint64_t>(rawData, pubKey);
-    }
+        case RSA_64 / 4: {
+            return encodeArray<uint64_t>(rawData, pubKey);
+        }
 
-    case RSA_128 / 4: {
-        return encodeArray<uint128_t>(rawData, pubKey);
-    }
+        case RSA_128 / 4: {
+            return encodeArray<uint128_t>(rawData, pubKey);
+        }
 
-    default: return QByteArray();
+        default: return QByteArray();
     }
 }
 
 QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &privKey) {
 
     switch (privKey.size()) {
-    case RSA_64 / 4: {
-        return decodeArray<uint64_t>(rawData, privKey);
-    }
 
-    case RSA_128 / 4: {
-        return decodeArray<uint128_t>(rawData, privKey);
-    }
+        case RSA_64 / 4: {
+            return decodeArray<uint64_t>(rawData, privKey);
+        }
 
-    default: return QByteArray();
+        case RSA_128 / 4: {
+            return decodeArray<uint128_t>(rawData, privKey);
+        }
+
+        default: return QByteArray();
     }
 }
 
-// EDS (electronic digital signature)
+// EDS (digital signature)
 QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &privKey) {
 
     QByteArray hash = QCryptographicHash::hash(rawData, QCryptographicHash::Sha256);
 
     QByteArray signature = encode(hash, privKey);
 
-    // signature size insert to 0 pos of message and takes up [sizeof(int)] bytes
-    int signatureSize = signature.size();
-    rawData.insert(0, reinterpret_cast<char*>(&signatureSize), sizeof(int));
-
-    rawData.append(signature);
+    rawData.append(SIGN_MARKER + signature.toHex() + SIGN_MARKER);
 
     return rawData;
 }
@@ -385,14 +350,14 @@ QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &pri
 // check valid EDS
 bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey) {
 
-    int signatureSize{0};
-    memcpy(&signatureSize, rawData.left(sizeof(int)), sizeof(int));
+    auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - QString(SIGN_MARKER).length() - 1),
+         signLength   = rawData.length() - signStartPos - QString(SIGN_MARKER).length() * 2;
 
     // message, that was recieved from channel
-    QByteArray message = rawData.mid(sizeof(int), rawData.size() - signatureSize - sizeof(int));
+    QByteArray message = rawData.left(signStartPos);
 
     // signature, that was recieved and decrypt from channel
-    QByteArray signature = decode(rawData.mid(rawData.size() - signatureSize),
+    QByteArray signature = decode(QByteArray::fromHex(rawData.mid(signStartPos + QString(SIGN_MARKER).length(), signLength)),
                                   pubKey);
 
     // if decrypt signature == sha256(recived message), then signed message is valid
@@ -433,5 +398,3 @@ bool QRSAEncryption::generatePairKey(QByteArray &pubKey,
 unsigned int QRSAEncryption::getBytesSize(QRSAEncryption::Rsa rsa) {
     return rsa / 8;
 }
-
-

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -16,7 +16,9 @@
 #include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
-#define SIGN_MARKER "-SIGN-"
+
+static const QString SIGN_MARKER = "-SIGN-";
+static const int signMarkerLength = SIGN_MARKER.length();
 
 class QRSAEncryption
 {

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -10,6 +10,7 @@
 
 #include <QByteArray>
 #include <QList>
+#include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
 

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -10,14 +10,20 @@
 
 #include <QByteArray>
 #include <QList>
+#include <QFile>
+#include <cmath>
+#include <QDebug>
 #include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
+#define SIGN_MARKER "-SIGN-"
 
 class QRSAEncryption
 {
+
 private:
     bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey);
+
 public:
 
     enum Rsa {

--- a/src/Qt-Secret.pri
+++ b/src/Qt-Secret.pri
@@ -22,6 +22,3 @@ win32:LIBS += -L$$Qt_SECRET_LIB_OUTPUT_DIR -lQt-Secret1
 
 INCLUDEPATH += "$$PWD/Qt-RSA"
 INCLUDEPATH += "$$PWD/Qt-AES"
-
-
-

--- a/src/Qt-Secret.pro
+++ b/src/Qt-Secret.pro
@@ -8,7 +8,7 @@
 QT -= gui
 CONFIG += c++17
 
-TARGET=Qt-Secret
+TARGET = Qt-Secret
 TEMPLATE = lib
 
 DEFINES += Qt_SECRET_LIBRARY
@@ -23,15 +23,12 @@ CONFIG(release, debug|release): {
 
 #include($$PWD/../uint256_t/uint256.pri)
 
-
 VERSION = 1.0.0
 
-HEADERS += \
-    Qt-AES/qaesencryption.h \
-    qtsecret_global.h \
-    Qt-RSA/qrsaencryption.h
+HEADERS += Qt-AES/qaesencryption.h \
+           qtsecret_global.h \
+           Qt-RSA/qrsaencryption.h
 
-SOURCES += \
-    Qt-AES/qaesencryption.cpp \
-    Qt-RSA/qrsaencryption.cpp
+SOURCES += Qt-AES/qaesencryption.cpp \
+           Qt-RSA/qrsaencryption.cpp
 

--- a/src/Qt-Secret.pro
+++ b/src/Qt-Secret.pro
@@ -21,11 +21,6 @@ CONFIG(release, debug|release): {
     DESTDIR="$$PWD/build/debug"
 }
 
-<<<<<<< HEAD
-#include($$PWD/../uint256_t/uint256.pri)
-=======
->>>>>>> 6a1e59163b9fc38c6570217d012be116a10badff
-
 VERSION = 1.0.0
 
 HEADERS += Qt-AES/qaesencryption.h \


### PR DESCRIPTION
Changed methods formation of digital signature. Methods `signMessage` and `checkSignMessage` now use sha256 to obtain EDS. (resolved bug #3) 