### PR TITLE
added static methods, added limit on a key pairs generation

### DIFF
--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -289,8 +289,7 @@ QByteArray decodeArray(const QByteArray &rawData, const QByteArray &privKey) {
     return res.remove(res.lastIndexOf(ENDLINE), res.size());
 }
 
-QRSAEncryption::QRSAEncryption()
-{
+QRSAEncryption::QRSAEncryption() {
 }
 
 unsigned int QRSAEncryption::getBytesSize(QRSAEncryption::Rsa rsa) {
@@ -303,26 +302,26 @@ bool QRSAEncryption::generatePairKeyS(QByteArray &pubKey, QByteArray &privKey,
 
     return QRSAEncryption().generatePairKey(pubKey, privKey, rsa);
 }
-QByteArray QRSAEncryption::encodeS(const QByteArray &rawData, const QByteArray &pubKey)
-{
+QByteArray QRSAEncryption::encodeS(const QByteArray &rawData, const QByteArray &pubKey) {
+
     return QRSAEncryption().encode(rawData, pubKey);
 }
-QByteArray QRSAEncryption::decodeS(const QByteArray &rawData, const QByteArray &privKey)
-{
+QByteArray QRSAEncryption::decodeS(const QByteArray &rawData, const QByteArray &privKey) {
+
     return QRSAEncryption().decode(rawData, privKey);
 }
-QByteArray QRSAEncryption::signMessageS(QByteArray rawData, const QByteArray &privKey)
-{
+QByteArray QRSAEncryption::signMessageS(QByteArray rawData, const QByteArray &privKey) {
+
     return QRSAEncryption().signMessage(rawData, privKey);
 }
-bool QRSAEncryption::checkSignMessageS(const QByteArray &rawData, const QByteArray &pubKey)
-{
+bool QRSAEncryption::checkSignMessageS(const QByteArray &rawData, const QByteArray &pubKey) {
+
     return QRSAEncryption().checkSignMessage(rawData, pubKey);
 }
 // --- end of static methods ---
 
-bool QRSAEncryption::generatePairKey(QByteArray &pubKey, QByteArray &privKey, QRSAEncryption::Rsa rsa)
-{
+bool QRSAEncryption::generatePairKey(QByteArray &pubKey, QByteArray &privKey, QRSAEncryption::Rsa rsa) {
+
     int cnt{0};
     bool keyGenRes{false};
 
@@ -384,8 +383,8 @@ QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &p
 
     return QByteArray();
 }
-QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &privKey)
-{
+QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &privKey) {
+
     QByteArray hash = QCryptographicHash::hash(rawData, HashAlgorithm::Sha256);
 
     QByteArray signature = encode(hash, privKey);
@@ -394,8 +393,8 @@ QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &pri
 
     return rawData;
 }
-bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey)
-{
+bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey) {
+
     // start position of SIGN_MARKER in rawData
     auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - signMarkerLength - 1);
 

--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -326,19 +326,10 @@ QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &p
         case RSA_64 / 4: {
             return decodeArray<uint64_t>(rawData, privKey);
         }
-<<<<<<< HEAD
 
         case RSA_128 / 4: {
             return decodeArray<uint128_t>(rawData, privKey);
         }
-
-=======
-
-        case RSA_128 / 4: {
-            return decodeArray<uint128_t>(rawData, privKey);
-        }
-
->>>>>>> 3f9ad7c6888202cffa30019e90b186cf988e82a7
         default: return QByteArray();
     }
 }
@@ -358,18 +349,21 @@ QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &pri
 // check valid EDS
 bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey) {
 
-    auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - QString(SIGN_MARKER).length() - 1),
-         signLength   = rawData.length() - signStartPos - QString(SIGN_MARKER).length() * 2;
+    // start position of SIGN_MARKER in rawData
+    auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - signMarkerLength - 1);
+
+    // length of signature in rawData
+    auto signLength   = rawData.length() - signStartPos - signMarkerLength * 2;
 
     // message, that was recieved from channel
     QByteArray message = rawData.left(signStartPos);
 
-    // signature, that was recieved and decrypt from channel
-    QByteArray signature = decode(QByteArray::fromHex(rawData.mid(signStartPos + QString(SIGN_MARKER).length(), signLength)),
-                                  pubKey);
+    // hash, that was decrypt from recieved signature
+    QByteArray recievedHash = decode(QByteArray::fromHex(rawData.mid(signStartPos + signMarkerLength, signLength)),
+                                     pubKey);
 
-    // if decrypt signature == sha256(recived message), then signed message is valid
-    return signature == QCryptographicHash::hash(message, QCryptographicHash::Sha256);
+    // if recievedHash == sha256(recived message), then signed message is valid
+    return recievedHash == QCryptographicHash::hash(message, QCryptographicHash::Sha256);
 }
 
 bool QRSAEncryption::generatePairKey(QByteArray &pubKey,

--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -6,37 +6,26 @@
 //#
 
 #include "qrsaencryption.h"
-#include <QFile>
-#include <cmath>
-#include <QDebug>
-
-#include <QDateTime>
-#include <time.h>
 
 typedef unsigned __int128  uint128_t;
 typedef signed __int128  int128_t;
 
-// функция эйлера
 template<class INT>
 INT eulerFunc(const INT &p, const INT &q) {
     return (p - 1) * (q - 1);
 }
 
-// перемножение по моудлю
 template<class INT>
 INT mul(INT a, INT b, const INT &m) {
     INT res = 0;
     while (a != 0) {
-        // если a - нечетное
-        if (a & 1)
-            res = (res + b) % m;
+        if (a & 1) res = (res + b) % m;
         a >>= 1;
         b = (b << 1) % m;
     }
     return res;
 }
 
-// возведение в степень по модулю
 template<class INT>
 INT pows(const INT &a, const INT &b, const INT &m) {
     if(b == 0)
@@ -45,7 +34,7 @@ INT pows(const INT &a, const INT &b, const INT &m) {
         INT t = pows(a, b / 2, m);
         return mul(t , t, m) % m;
     }
-    return ( mul(pows(a, b - 1, m) , a, m) ) % m;
+    return ( mul(pows(a, b - 1, m), a, m)) % m;
 }
 
 template<class INT>
@@ -61,7 +50,6 @@ INT binpow (INT a, INT n, INT m) {
     return res % m;
 }
 
-// наибольший общий делитель, для взаимно простых == 1
 template<class INT>
 bool gcd(INT a, INT b) {
     INT c;
@@ -73,53 +61,45 @@ bool gcd(INT a, INT b) {
     return b;
 }
 
-// проверка на взаимную простоту
 template<class INT>
 bool isMutuallyPrime(INT a, INT b) {
     if (        (!(a % 2) && !(b % 2))
              || (!(a % 3) && !(b % 3))
              || (!(a % 5) && !(b % 5))
              || (!(a % 7) && !(b % 7))
-       ) {
-        return false;
-    }
+       ) return false;
 
     return gcd(a, b) == 1;
 }
 
-// количество бит в INT
 template<class INT>
 unsigned int getBitsSize() {
     return sizeof(INT) * 8;
 }
 
-// случайное число INT
 template<class INT>
 INT randNumber() {
     srand(std::chrono::duration_cast<std::chrono::nanoseconds>
           (std::chrono::system_clock::now().time_since_epoch()).count()
           % std::numeric_limits<int>::max());
 
-    // сколько int укладывается в INT
     int longDiff = getBitsSize<INT>() / (sizeof (int) * 8);
 
     INT res = 1;
 
-    while(longDiff > 0){
+    while (longDiff > 0) {
         longDiff--;
-
         res *= rand() % std::numeric_limits<int>::max();
     }
 
     return res;
 }
 
-// тест ферма
+// Ferma test
 template<class INT>
 bool isPrimeFerma(INT x){
 
-    if(x == 2)
-        return true;
+    if(x == 2) return true;
 
     for(int i = 0; i < 100; i++){
         INT a = (randNumber<INT>() % (x - 2)) + 2;
@@ -133,7 +113,7 @@ bool isPrimeFerma(INT x){
     return true;
 }
 
-// поиск ближайшего простого числа
+// return nearest prime number
 template<class INT>
 INT toPrime(INT n) {
 
@@ -145,26 +125,22 @@ INT toPrime(INT n) {
     INT RN = n;
 
     while (true) {
-        if (isPrimeFerma(LN)) {
-            return LN;
-        }
+
+        if (isPrimeFerma(LN)) return LN;
 
         RN+=2;
 
-        if (isPrimeFerma(RN)) {
-            return RN;
-        }
-
+        if (isPrimeFerma(RN)) return RN;
         LN-=2;
     }
 }
 
-// случайное простое число, не равное no
 template<class INT>
 INT randomPrimeNumber(INT no = 0) {
 
     srand(static_cast<unsigned int>(time(nullptr)));
 
+    // max INT
     auto max = (~((INT(1)) << (getBitsSize<INT>() - 1))) >> ((getBitsSize<INT>()) >> 1);
 
     auto p = toPrime(randNumber<INT>() % max);
@@ -214,7 +190,6 @@ INT fromArray(const QByteArray& array) {
     return res;
 }
 
-// генерация ключей
 template<class INT>
 bool keyGenerator(QByteArray &pubKey,
                   QByteArray &privKey) {
@@ -227,16 +202,13 @@ bool keyGenerator(QByteArray &pubKey,
         p = toPrime((p - 1) / 2);
     }
 
-    INT eilor = eulerFunc(p, q); // (p-1)*(q-1)
+    INT eilor = eulerFunc(p, q);
     INT e = randNumber<INT>() % eilor;
-
-    // d,e: d*e = 1 mod eilor
 
     if (!(e % 2)) e--;
 
     do {
         e -= 2;
-
     } while((!isMutuallyPrime(eilor, e)));
 
     INT d = ExtEuclid<INT>(eilor , e);;
@@ -253,7 +225,6 @@ bool keyGenerator(QByteArray &pubKey,
     return true;
 }
 
-// округляет в нижнюю сторону кол-во байт, отводимых под число i
 template< class INT>
 short getBytes(INT i) {
     return static_cast<short>(std::floor(log2(i) / 8));
@@ -319,15 +290,12 @@ QByteArray decodeArray(const QByteArray &rawData, const QByteArray &privKey) {
     return res.remove(res.lastIndexOf(ENDLINE), res.size());
 }
 
-// проверка ключей
 bool QRSAEncryption::testKeyPair(const QByteArray &pubKey, const QByteArray &privKey) {
     QByteArray tesVal = "Test message of encrypkey";
 
     bool result = tesVal == decode(encode(tesVal, pubKey), privKey);
 
-    if (!result) {
-        qWarning() << "(Warning): Testkey Fail, try generate new key pair!";
-    }
+    if (!result) qWarning() << "(Warning): Testkey Fail, try generate new key pair!";
 
     return result;
 }
@@ -339,45 +307,42 @@ QRSAEncryption::QRSAEncryption() {
 QByteArray QRSAEncryption::encode(const QByteArray &rawData, const QByteArray &pubKey) {
 
     switch (pubKey.size()) {
-    case RSA_64 / 4: {
-        return encodeArray<uint64_t>(rawData, pubKey);
-    }
+        case RSA_64 / 4: {
+            return encodeArray<uint64_t>(rawData, pubKey);
+        }
 
-    case RSA_128 / 4: {
-        return encodeArray<uint128_t>(rawData, pubKey);
-    }
+        case RSA_128 / 4: {
+            return encodeArray<uint128_t>(rawData, pubKey);
+        }
 
-    default: return QByteArray();
+        default: return QByteArray();
     }
 }
 
 QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &privKey) {
 
     switch (privKey.size()) {
-    case RSA_64 / 4: {
-        return decodeArray<uint64_t>(rawData, privKey);
-    }
 
-    case RSA_128 / 4: {
-        return decodeArray<uint128_t>(rawData, privKey);
-    }
+        case RSA_64 / 4: {
+            return decodeArray<uint64_t>(rawData, privKey);
+        }
 
-    default: return QByteArray();
+        case RSA_128 / 4: {
+            return decodeArray<uint128_t>(rawData, privKey);
+        }
+
+        default: return QByteArray();
     }
 }
 
-// EDS (electronic digital signature)
+// EDS (digital signature)
 QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &privKey) {
 
     QByteArray hash = QCryptographicHash::hash(rawData, QCryptographicHash::Sha256);
 
     QByteArray signature = encode(hash, privKey);
 
-    // signature size insert to 0 pos of message and takes up [sizeof(int)] bytes
-    int signatureSize = signature.size();
-    rawData.insert(0, reinterpret_cast<char*>(&signatureSize), sizeof(int));
-
-    rawData.append(signature);
+    rawData.append(SIGN_MARKER + signature.toHex() + SIGN_MARKER);
 
     return rawData;
 }
@@ -385,14 +350,14 @@ QByteArray QRSAEncryption::signMessage(QByteArray rawData, const QByteArray &pri
 // check valid EDS
 bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey) {
 
-    int signatureSize{0};
-    memcpy(&signatureSize, rawData.left(sizeof(int)), sizeof(int));
+    auto signStartPos = rawData.lastIndexOf(SIGN_MARKER, rawData.length() - QString(SIGN_MARKER).length() - 1),
+         signLength   = rawData.length() - signStartPos - QString(SIGN_MARKER).length() * 2;
 
     // message, that was recieved from channel
-    QByteArray message = rawData.mid(sizeof(int), rawData.size() - signatureSize - sizeof(int));
+    QByteArray message = rawData.left(signStartPos);
 
     // signature, that was recieved and decrypt from channel
-    QByteArray signature = decode(rawData.mid(rawData.size() - signatureSize),
+    QByteArray signature = decode(QByteArray::fromHex(rawData.mid(signStartPos + QString(SIGN_MARKER).length(), signLength)),
                                   pubKey);
 
     // if decrypt signature == sha256(recived message), then signed message is valid
@@ -433,5 +398,3 @@ bool QRSAEncryption::generatePairKey(QByteArray &pubKey,
 unsigned int QRSAEncryption::getBytesSize(QRSAEncryption::Rsa rsa) {
     return rsa / 8;
 }
-
-

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -16,7 +16,9 @@
 #include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
-#define SIGN_MARKER "-SIGN-"
+
+static const QString SIGN_MARKER = "-SIGN-";
+static const int signMarkerLength = SIGN_MARKER.length();
 
 class QRSAEncryption
 {

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -16,35 +16,51 @@
 #include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
+#define KEY_GEN_LIMIT 10
 
 static const QString SIGN_MARKER = "-SIGN-";
 static const int signMarkerLength = SIGN_MARKER.length();
 
+typedef QCryptographicHash::Algorithm HashAlgorithm;
+
 class QRSAEncryption
 {
 
-private:
-    bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey);
-
 public:
-
     enum Rsa {
         RSA_64 = 64,
         RSA_128 = 128
     };
 
-    QRSAEncryption();
+    QRSAEncryption(QRSAEncryption::Rsa _keyLength);
 
+    unsigned int getBytesSize(QRSAEncryption::Rsa keyLength);
+
+// static methods
+    static bool generatePairKey(QByteArray &pubKey, QByteArray &privKey,
+                                QRSAEncryption::Rsa);
+    static QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
+                            QRSAEncryption::Rsa keyLength);
+    static QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,
+                              QRSAEncryption::Rsa keyLength);
+    static QByteArray signMessage(QByteArray rawData, const QByteArray &privKey,
+                                  QRSAEncryption::Rsa keyLength);
+    static bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey,
+                                 QRSAEncryption::Rsa keyLength);
+
+// non-static methods
+    bool generatePairKey(QByteArray &pubKey, QByteArray &privKey);
     QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey);
     QByteArray decode(const QByteArray &rawData, const QByteArray &privKey);
-
     QByteArray signMessage(QByteArray rawData, const QByteArray &privKey);
     bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey);
 
-    bool generatePairKey(QByteArray &pubKey, QByteArray &privKey, Rsa = RSA_128);
+private:
+    bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey,
+                     QRSAEncryption::Rsa keyLength = RSA_64);
 
-    static unsigned int getBytesSize(Rsa rsa);
-
+private:
+    Rsa keyLength;
 };
 
 #endif // QRSAENCRYPTION_H

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -10,6 +10,7 @@
 
 #include <QByteArray>
 #include <QList>
+#include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
 

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -38,31 +38,22 @@ public:
 
 // static methods
     static bool generatePairKeyS(QByteArray &pubKey, QByteArray &privKey,
-                                 QRSAEncryption::Rsa);
-    static QByteArray encodeS(const QByteArray &rawData, const QByteArray &pubKey,
-                              QRSAEncryption::Rsa rsa);
-    static QByteArray decodeS(const QByteArray &rawData, const QByteArray &privKey,
-                              QRSAEncryption::Rsa rsa);
-    static QByteArray signMessageS(QByteArray rawData, const QByteArray &privKey,
                                  QRSAEncryption::Rsa rsa);
-    static bool checkSignMessageS(const QByteArray &rawData, const QByteArray &pubKey,
-                                  QRSAEncryption::Rsa rsa);
+    static QByteArray encodeS(const QByteArray &rawData, const QByteArray &pubKey);
+    static QByteArray decodeS(const QByteArray &rawData, const QByteArray &privKey);
+    static QByteArray signMessageS(QByteArray rawData, const QByteArray &privKey);
+    static bool checkSignMessageS(const QByteArray &rawData, const QByteArray &pubKey);
 
 // non-static methods
     bool generatePairKey(QByteArray &pubKey, QByteArray &privKey,
                          QRSAEncryption::Rsa rsa);
-    QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
-                      QRSAEncryption::Rsa rsa);
-    QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,
-                      QRSAEncryption::Rsa rsa);
-    QByteArray signMessage(QByteArray rawData, const QByteArray &privKey,
-                           QRSAEncryption::Rsa rsa);
-    bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey,
-                          QRSAEncryption::Rsa rsa);
+    QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey);
+    QByteArray decode(const QByteArray &rawData, const QByteArray &privKey);
+    QByteArray signMessage(QByteArray rawData, const QByteArray &privKey);
+    bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey);
 
 private:
-    bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey,
-                     QRSAEncryption::Rsa rsa);
+    bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey);
 };
 
 #endif // QRSAENCRYPTION_H

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -10,14 +10,20 @@
 
 #include <QByteArray>
 #include <QList>
+#include <QFile>
+#include <cmath>
+#include <QDebug>
 #include <QCryptographicHash> // to use sha256
 
 #define ENDLINE "#_end_#"
+#define SIGN_MARKER "-SIGN-"
 
 class QRSAEncryption
 {
+
 private:
     bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey);
+
 public:
 
     enum Rsa {

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -32,35 +32,37 @@ public:
         RSA_128 = 128
     };
 
-    QRSAEncryption(QRSAEncryption::Rsa _keyLength);
+    QRSAEncryption();
 
     unsigned int getBytesSize(QRSAEncryption::Rsa keyLength);
 
 // static methods
-    static bool generatePairKey(QByteArray &pubKey, QByteArray &privKey,
-                                QRSAEncryption::Rsa);
-    static QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
-                            QRSAEncryption::Rsa keyLength);
-    static QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,
+    static bool generatePairKeyS(QByteArray &pubKey, QByteArray &privKey,
+                                 QRSAEncryption::Rsa);
+    static QByteArray encodeS(const QByteArray &rawData, const QByteArray &pubKey,
                               QRSAEncryption::Rsa keyLength);
-    static QByteArray signMessage(QByteArray rawData, const QByteArray &privKey,
-                                  QRSAEncryption::Rsa keyLength);
-    static bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey,
+    static QByteArray decodeS(const QByteArray &rawData, const QByteArray &privKey,
+                              QRSAEncryption::Rsa keyLength);
+    static QByteArray signMessageS(QByteArray rawData, const QByteArray &privKey,
                                  QRSAEncryption::Rsa keyLength);
+    static bool checkSignMessageS(const QByteArray &rawData, const QByteArray &pubKey,
+                                  QRSAEncryption::Rsa keyLength);
 
 // non-static methods
-    bool generatePairKey(QByteArray &pubKey, QByteArray &privKey);
-    QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey);
-    QByteArray decode(const QByteArray &rawData, const QByteArray &privKey);
-    QByteArray signMessage(QByteArray rawData, const QByteArray &privKey);
-    bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey);
+    bool generatePairKey(QByteArray &pubKey, QByteArray &privKey,
+                         QRSAEncryption::Rsa keyLength);
+    QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
+                      QRSAEncryption::Rsa keyLength);
+    QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,
+                      QRSAEncryption::Rsa keyLength);
+    QByteArray signMessage(QByteArray rawData, const QByteArray &privKey,
+                           QRSAEncryption::Rsa keyLength);
+    bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey,
+                          QRSAEncryption::Rsa keyLength);
 
 private:
     bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey,
-                     QRSAEncryption::Rsa keyLength = RSA_64);
-
-private:
-    Rsa keyLength;
+                     QRSAEncryption::Rsa keyLength);
 };
 
 #endif // QRSAENCRYPTION_H

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -34,35 +34,35 @@ public:
 
     QRSAEncryption();
 
-    unsigned int getBytesSize(QRSAEncryption::Rsa keyLength);
+    unsigned int getBytesSize(QRSAEncryption::Rsa rsa);
 
 // static methods
     static bool generatePairKeyS(QByteArray &pubKey, QByteArray &privKey,
                                  QRSAEncryption::Rsa);
     static QByteArray encodeS(const QByteArray &rawData, const QByteArray &pubKey,
-                              QRSAEncryption::Rsa keyLength);
+                              QRSAEncryption::Rsa rsa);
     static QByteArray decodeS(const QByteArray &rawData, const QByteArray &privKey,
-                              QRSAEncryption::Rsa keyLength);
+                              QRSAEncryption::Rsa rsa);
     static QByteArray signMessageS(QByteArray rawData, const QByteArray &privKey,
-                                 QRSAEncryption::Rsa keyLength);
+                                 QRSAEncryption::Rsa rsa);
     static bool checkSignMessageS(const QByteArray &rawData, const QByteArray &pubKey,
-                                  QRSAEncryption::Rsa keyLength);
+                                  QRSAEncryption::Rsa rsa);
 
 // non-static methods
     bool generatePairKey(QByteArray &pubKey, QByteArray &privKey,
-                         QRSAEncryption::Rsa keyLength);
+                         QRSAEncryption::Rsa rsa);
     QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
-                      QRSAEncryption::Rsa keyLength);
+                      QRSAEncryption::Rsa rsa);
     QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,
-                      QRSAEncryption::Rsa keyLength);
+                      QRSAEncryption::Rsa rsa);
     QByteArray signMessage(QByteArray rawData, const QByteArray &privKey,
-                           QRSAEncryption::Rsa keyLength);
+                           QRSAEncryption::Rsa rsa);
     bool checkSignMessage(const QByteArray &rawData, const QByteArray &pubKey,
-                          QRSAEncryption::Rsa keyLength);
+                          QRSAEncryption::Rsa rsa);
 
 private:
     bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey,
-                     QRSAEncryption::Rsa keyLength);
+                     QRSAEncryption::Rsa rsa);
 };
 
 #endif // QRSAENCRYPTION_H

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -32,7 +32,7 @@ bool testCrypto(QRSAEncryption::Rsa rsa) {
     QRSAEncryption e;
 
     for (int i = 0; i < testSize; i++) {
-        QRSAEncryption::generatePairKeyS(pub, priv, rsa);
+        e.generatePairKeyS(pub, priv, rsa);
 
         qInfo() << QString("Test keys (%0/%1):").arg(i).arg(testSize);
         qInfo() << QString("Private key: %0").arg(QString(priv.toHex()));
@@ -84,7 +84,6 @@ bool testCrypto(QRSAEncryption::Rsa rsa) {
 
     return true;
 }
-
 
 int main() {
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -28,12 +28,11 @@ QByteArray randomArray() {
 }
 
 bool testCrypto(QRSAEncryption::Rsa rsa) {
-    QByteArray pub, priv;
-    QRSAEncryption e;
 
+    QByteArray pub, priv;
 
     for (int i = 0; i < testSize; i++) {
-        e.generatePairKey(pub, priv, rsa);
+        QRSAEncryption::generatePairKey(pub, priv, rsa);
 
         qInfo() << QString("Test keys (%0/%1):").arg(i).arg(testSize);
         qInfo() << QString("Private key: %0").arg(QString(priv.toHex()));
@@ -44,7 +43,6 @@ bool testCrypto(QRSAEncryption::Rsa rsa) {
             return false;
         }
 
-
         if (priv.size() != rsa / 4) {
             qCritical() << "privKey size wrong RSA" << rsa;
             return false;
@@ -53,17 +51,17 @@ bool testCrypto(QRSAEncryption::Rsa rsa) {
         for (int i = 0; i < testSize; i++) {
             auto base = randomArray();
 
-            auto encodeData = e.encode(base, pub);
-            auto decodeData = e.decode(encodeData, priv);
+            auto encodeData = QRSAEncryption(rsa).encode(base, pub);
+            auto decodeData = QRSAEncryption(rsa).decode(encodeData, priv);
 
             if ( base != decodeData) {
                 qCritical() << "encode/decode data error RSA" << rsa;
                 return false;
             }
 
-            encodeData = e.signMessage(base, priv);
+            encodeData = QRSAEncryption(rsa).signMessage(base, priv, rsa);
 
-            if (!e.checkSignMessage(encodeData, pub)) {
+            if (!QRSAEncryption(rsa).checkSignMessage(encodeData, pub, rsa)) {
                 qCritical() << "sig message error RSA" << rsa;
                 return false;
             }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -26,57 +26,57 @@ QByteArray randomArray() {
     return res;
 }
 
-bool testCrypto(QRSAEncryption::Rsa keyLength) {
+bool testCrypto(QRSAEncryption::Rsa rsa) {
 
     QByteArray pub, priv;
     QRSAEncryption e;
 
     for (int i = 0; i < testSize; i++) {
-        QRSAEncryption::generatePairKeyS(pub, priv, keyLength);
+        QRSAEncryption::generatePairKeyS(pub, priv, rsa);
 
         qInfo() << QString("Test keys (%0/%1):").arg(i).arg(testSize);
         qInfo() << QString("Private key: %0").arg(QString(priv.toHex()));
         qInfo() << QString("Public key: %0").arg(QString(pub.toHex()));
 
-        if (pub.size() != keyLength / 4) {
-            qCritical() << "pubKey size wrong RSA" << keyLength;
+        if (pub.size() != rsa / 4) {
+            qCritical() << "pubKey size wrong RSA" << rsa;
             return false;
         }
 
-        if (priv.size() != keyLength / 4) {
-            qCritical() << "privKey size wrong RSA" << keyLength;
+        if (priv.size() != rsa / 4) {
+            qCritical() << "privKey size wrong RSA" << rsa;
             return false;
         }
 
         for (int i = 0; i < testSize; i++) {
             auto base = randomArray();
 
-            auto encodeData = e.encode(base, pub, keyLength);
-            auto decodeData = e.decode(encodeData, priv, keyLength);
+            auto encodeData = e.encode(base, pub);
+            auto decodeData = e.decode(encodeData, priv);
 
             if ( base != decodeData) {
-                qCritical() << "encode/decode data error RSA" << keyLength;
+                qCritical() << "encode/decode data error RSA" << rsa;
                 return false;
             }
 
-            encodeData = e.signMessage(base, priv, keyLength);
+            encodeData = e.signMessage(base, priv);
 
-            if (!e.checkSignMessage(encodeData, pub, keyLength)) {
-                qCritical() << "sig message error RSA" << keyLength;
+            if (!e.checkSignMessage(encodeData, pub)) {
+                qCritical() << "sig message error RSA" << rsa;
                 return false;
             }
 
             encodeData += "work it";
 
-            if (e.checkSignMessage(encodeData, pub, keyLength)) {
-                qCritical() << "sig message error RSA with added value to back" << keyLength;
+            if (e.checkSignMessage(encodeData, pub)) {
+                qCritical() << "sig message error RSA with added value to back" << rsa;
                 return false;
             }
 
             encodeData.push_front("not work");
 
-            if (e.checkSignMessage(encodeData, pub, keyLength)) {
-                qCritical() << "sig message error RSA with added value to front" << keyLength;
+            if (e.checkSignMessage(encodeData, pub)) {
+                qCritical() << "sig message error RSA with added value to front" << rsa;
                 return false;
             }
         }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -29,10 +29,10 @@ QByteArray randomArray() {
 bool testCrypto(QRSAEncryption::Rsa keyLength) {
 
     QByteArray pub, priv;
-    QRSAEncryption e(keyLength);
+    QRSAEncryption e;
 
     for (int i = 0; i < testSize; i++) {
-        QRSAEncryption::generatePairKey(pub, priv, keyLength);
+        QRSAEncryption::generatePairKeyS(pub, priv, keyLength);
 
         qInfo() << QString("Test keys (%0/%1):").arg(i).arg(testSize);
         qInfo() << QString("Private key: %0").arg(QString(priv.toHex()));
@@ -51,8 +51,8 @@ bool testCrypto(QRSAEncryption::Rsa keyLength) {
         for (int i = 0; i < testSize; i++) {
             auto base = randomArray();
 
-            auto encodeData = e.encode(base, pub);
-            auto decodeData = e.decode(encodeData, priv);
+            auto encodeData = e.encode(base, pub, keyLength);
+            auto decodeData = e.decode(encodeData, priv, keyLength);
 
             if ( base != decodeData) {
                 qCritical() << "encode/decode data error RSA" << keyLength;
@@ -68,14 +68,14 @@ bool testCrypto(QRSAEncryption::Rsa keyLength) {
 
             encodeData += "work it";
 
-            if (e.checkSignMessage(encodeData, pub)) {
+            if (e.checkSignMessage(encodeData, pub, keyLength)) {
                 qCritical() << "sig message error RSA with added value to back" << keyLength;
                 return false;
             }
 
             encodeData.push_front("not work");
 
-            if (e.checkSignMessage(encodeData, pub)) {
+            if (e.checkSignMessage(encodeData, pub, keyLength)) {
                 qCritical() << "sig message error RSA with added value to front" << keyLength;
                 return false;
             }

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -32,7 +32,7 @@ bool testCrypto(QRSAEncryption::Rsa rsa) {
     QRSAEncryption e;
 
     for (int i = 0; i < testSize; i++) {
-        e.generatePairKeyS(pub, priv, rsa);
+        e.generatePairKey(pub, priv, rsa);
 
         qInfo() << QString("Test keys (%0/%1):").arg(i).arg(testSize);
         qInfo() << QString("Private key: %0").arg(QString(priv.toHex()));


### PR DESCRIPTION
added static methods to `encode`/`decode`, `signMessage`/`checkSign` and `generatePairKey `#4 

in method `generatePairKey` added limit on a max iterations to key pair generate #9 

in third test removed inverting, because tests were performed incorrectly with it