### PR TITLE
Added support of genesis of RSA pair keys.

### DIFF
--- a/src/Qt-RSA/qrsaencryption.cpp
+++ b/src/Qt-RSA/qrsaencryption.cpp
@@ -22,7 +22,7 @@ QRSAEncryption::INT eulerFunc(const QRSAEncryption::INT &p, const QRSAEncryption
     return (p - 1) * (q - 1);
 }
 
-bool QRSAEncryption::isMutuallyPrime(const INT &a, const INT &b) {
+bool QRSAEncryption::isMutuallyPrime(const INT &a, const INT &b) const {
     if (        (!(a % 2) && !(b % 2))
                 || (!(a % 3) && !(b % 3))
                 || (!(a % 5) && !(b % 5))
@@ -58,7 +58,7 @@ QRSAEncryption::INT QRSAEncryption::fromArray(const QByteArray &array) const {
     return res;
 }
 
-QByteArray QRSAEncryption::toArray(const INT &i, short sizeBlok) {
+QByteArray QRSAEncryption::toArray(const INT &i, short sizeBlok) const {
     QByteArray res;
     res = QByteArray::fromHex(QByteArray::fromStdString(i.getString(16)));
 
@@ -151,14 +151,35 @@ short QRSAEncryption::getBlockSize(INT i) const {
     return static_cast<short>(i.longBytes()) - 1;
 }
 
-QByteArray QRSAEncryption::encodeBlok(const INT &block, const INT &e, const INT &m, short blockSize) {
+QByteArray QRSAEncryption::encodeBlok(const INT &block, const INT &e, const INT &m, short blockSize) const {
 
     return toArray(INT::powm(block, e, m), blockSize);
 }
 
-QByteArray QRSAEncryption::decodeBlok(const INT &block, const INT &d, const INT &m, short blockSize) {
+QByteArray QRSAEncryption::decodeBlok(const INT &block, const INT &d, const INT &m, short blockSize) const {
 
     return toArray(INT::powm(block, d, m), blockSize);
+}
+
+void QRSAEncryption::getPrimesFromGenesis(const QByteArray &genesis,
+                                          QRSAEncryption::INT &prime1,
+                                          QRSAEncryption::INT &prime2) const {
+
+    auto hash = QCryptographicHash::hash(genesis, QCryptographicHash::Sha512);
+
+    INT p1, p2;
+    p1.fromHex(hash.left(hash.size() / 2).toHex().toStdString());
+    p2.fromHex(hash.right(hash.size() / 2).toHex().toStdString());
+
+    int powP1 = std::trunc((_rsa / 4) / p1.sizeBits());
+    int powP2 = std::trunc((_rsa / 4) / p2.sizeBits());
+
+    p1.pow(powP1);
+    p2.pow(powP2);
+
+    prime1 = toPrime(p1);
+    prime2 = toPrime(p2);
+
 }
 
 QRSAEncryption::QRSAEncryption(Rsa rsa) {
@@ -214,7 +235,7 @@ bool QRSAEncryption::checkSignMessage(const QByteArray &rawData, const QByteArra
 
 // --- end of static methods ---
 
-bool QRSAEncryption::generatePairKey(QByteArray &pubKey, QByteArray &privKey) {
+bool QRSAEncryption::generatePairKey(QByteArray &pubKey, QByteArray &privKey, const QByteArray &genesis) const {
 
     int cnt{0};
     bool keyGenRes{false};
@@ -224,8 +245,13 @@ bool QRSAEncryption::generatePairKey(QByteArray &pubKey, QByteArray &privKey) {
         pubKey.clear();
         privKey.clear();
 
-        p = randomPrimeNumber();
-        q = randomPrimeNumber(p);
+        if (genesis.size()) {
+            getPrimesFromGenesis(genesis, p, q);
+        } else {
+            p = randomPrimeNumber();
+            q = randomPrimeNumber(p);
+        }
+
 
         modul = 0;
         while ((modul = p * q) < 0) {
@@ -260,7 +286,7 @@ bool QRSAEncryption::generatePairKey(QByteArray &pubKey, QByteArray &privKey) {
 }
 
 // --- non-static methods ---
-QByteArray QRSAEncryption::encode(const QByteArray &rawData, const QByteArray &pubKey, BlockSize blockSizeMode) {
+QByteArray QRSAEncryption::encode(const QByteArray &rawData, const QByteArray &pubKey, BlockSize blockSizeMode) const {
 
     if (getBitsSize(pubKey) != _rsa) {
         return QByteArray();
@@ -302,7 +328,7 @@ QByteArray QRSAEncryption::encode(const QByteArray &rawData, const QByteArray &p
     return res;
 
 }
-QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &privKey, BlockSize blockSizeMode) {
+QByteArray QRSAEncryption::decode(const QByteArray &rawData, const QByteArray &privKey, BlockSize blockSizeMode) const {
 
     if (getBitsSize(privKey) != _rsa) {
         return QByteArray();
@@ -398,7 +424,7 @@ QRSAEncryption::Rsa QRSAEncryption::getRsa() const {
     return _rsa;
 }
 
-bool QRSAEncryption::testKeyPair(const QByteArray &pubKey, const QByteArray &privKey) {
+bool QRSAEncryption::testKeyPair(const QByteArray &pubKey, const QByteArray &privKey) const {
 
     QByteArray tesVal = "Test message of encrypkey";
 

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -45,13 +45,13 @@ To ensure reliable protection, it is recommended to use an exponent size of at l
     };
 
     /**
-     * @brief The BlockSize enum defined size of block of key
-     * Auto - fast but not stable. (using by default)
-     * OneByte - // stable but slow. (using for sig and check sig messages)
+     * @brief The BlockSize enum defined size of block of key.
      */
     enum BlockSize {
-        Auto = 0, // fast but not stable. (using by default)
-        OneByte = 1 // stable but slow. (using for sig and check sig messages)
+        /// Fast but not stable. (using by default)
+        Auto = 0,
+        /// Stable but slow. (using for sig and check sig messages)
+        OneByte = 1
     };
 
 
@@ -157,9 +157,15 @@ To ensure reliable protection, it is recommended to use an exponent size of at l
      * @brief generatePairKey - generate RSA pair keys
      * @param pubKey - return value of pablic key
      * @param privKey - return value of private key
+     * @param genesis - random bytes of arbitrary size.
+     *  This option allows you to generate a key pair that is attached to a given set of bytes.
+     *  Example if you set the value to 0xFF, then you will always get the same key pair attached to this value.
+     *  This can be convenient if you have some kind of super key by which you want to generate a pair of RSA keys.
+     * @note Leave genesis empty to generate random keys.
+     * @warning  The keys will not be the same if you generate RSA keys of different sizes.
      * @return true if all good.
      */
-    bool generatePairKey(QByteArray &pubKey, QByteArray &privKey);
+    bool generatePairKey(QByteArray &pubKey, QByteArray &privKey, const QByteArray& genesis = {}) const;
 
     /**
      * @brief encode - encode rawData
@@ -169,7 +175,7 @@ To ensure reliable protection, it is recommended to use an exponent size of at l
      * @return The encoded data.
      */
     QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
-                      BlockSize blockSizeMode = BlockSize::Auto);
+                      BlockSize blockSizeMode = BlockSize::Auto) const;
 
     /**
      * @brief decode - decode raw encoded data.
@@ -180,7 +186,7 @@ To ensure reliable protection, it is recommended to use an exponent size of at l
      * @return decoded data
      */
     QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,
-                      BlockSize blockSizeMode = BlockSize::Auto);
+                      BlockSize blockSizeMode = BlockSize::Auto) const;
 
     /**
      * @brief signMessage
@@ -208,13 +214,13 @@ private:
 
     Rsa _rsa;
 
-    bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey);
-    bool isMutuallyPrime(const INT &a, const INT &b);
+    bool testKeyPair(const QByteArray &pubKey, const QByteArray &privKey) const;
+    bool isMutuallyPrime(const INT &a, const INT &b) const;
     Rsa getBitsSize(const INT& i) const;
     Rsa getBitsSize(const QByteArray& array) const;
 
     INT fromArray(const QByteArray& array) const;
-    QByteArray toArray(const INT &i, short sizeBlok = -1);
+    QByteArray toArray(const INT &i, short sizeBlok = -1) const;
     INT randomNumber(bool fullFilled = true) const;
     INT toPrime(INT) const;
     INT randomPrimeNumber(INT no = 0) const;
@@ -222,8 +228,9 @@ private:
 
     short getBlockSize(INT i) const;
 
-    QByteArray encodeBlok(const INT& block, const INT& e, const INT& m, short blockSize);
-    QByteArray decodeBlok(const INT& block, const INT& d, const INT& m, short blockSize);
+    QByteArray encodeBlok(const INT& block, const INT& e, const INT& m, short blockSize) const;
+    QByteArray decodeBlok(const INT& block, const INT& d, const INT& m, short blockSize) const;
+    void getPrimesFromGenesis(const QByteArray& genesis, INT& prime1, INT& prime2) const;
 
 
 };

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -171,7 +171,7 @@ To ensure reliable protection, it is recommended to use an exponent size of at l
      * @brief encode - encode rawData
      * @param rawData - data for encode
      * @param pubKey - public key. Public key size must be equals size of RSA class.
-     * @param blockSizeMode - block size. See @BlockSize
+     * @param blockSizeMode - block size. See BlockSize
      * @return The encoded data.
      */
     QByteArray encode(const QByteArray &rawData, const QByteArray &pubKey,
@@ -182,7 +182,7 @@ To ensure reliable protection, it is recommended to use an exponent size of at l
      * it is important that the data is decrypted and encrypted by the same class, or in the case of static methods with the same parameters
      * @param rawData - ecoded data.
      * @param privKey - private RSA key
-     * @param blockSizeMode - block size mode see @BlockSize
+     * @param blockSizeMode - block size mode see BlockSize
      * @return decoded data
      */
     QByteArray decode(const QByteArray &rawData, const QByteArray &privKey,

--- a/src/Qt-RSA/qrsaencryption.h
+++ b/src/Qt-RSA/qrsaencryption.h
@@ -231,6 +231,7 @@ private:
     QByteArray encodeBlok(const INT& block, const INT& e, const INT& m, short blockSize) const;
     QByteArray decodeBlok(const INT& block, const INT& d, const INT& m, short blockSize) const;
     void getPrimesFromGenesis(const QByteArray& genesis, INT& prime1, INT& prime2) const;
+    INT genesisInt(const QByteArray& genesis, int limitBits) const;
 
 
 };

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -97,10 +97,30 @@ bool checkKeys(const QByteArray& pubKey, const QByteArray& privKey,
     return true;
 }
 
+bool testGenesis(const QRSAEncryption& e) {
+    QByteArray
+    pubGenesis1, privGenesis1,
+    pubGenesis2, privGenesis2;
+
+    // check genesis
+    auto genesis = randomArray(0xFFFF);
+    if (!e.generatePairKey(pubGenesis1, privGenesis1, genesis)) {
+        print( "Fail to test genesis got generation keys " + QString::number(e.getRsa()));
+        return false;
+    }
+
+    if (!e.generatePairKey(pubGenesis2, privGenesis2, genesis)) {
+        print( "Fail to test genesis got generation keys " + QString::number(e.getRsa()));
+        return false;
+    }
+
+    return pubGenesis1 == pubGenesis2 && privGenesis1 == privGenesis2;
+};
 
 bool testCrypto(QRSAEncryption::Rsa rsa) {
 
     QByteArray pub, priv;
+
     QRSAEncryption e(rsa);
 
     for (int i = 0; i < testSize[rsa]; i++) {
@@ -109,6 +129,11 @@ bool testCrypto(QRSAEncryption::Rsa rsa) {
 
         if (!e.generatePairKey(pub, priv)) {
             print( "key not generated RSA" + QString::number(rsa));
+            return false;
+        }
+
+        if (!testGenesis(e)) {
+            print( "Test genesis failed. RSA" + QString::number(rsa));
             return false;
         }
 


### PR DESCRIPTION
*  This option allows you to generate a key pair that is attached to a given set of bytes.
*  Example if you set the value to 0xFF, then you will always get the same key pair attached to this value.
*  This can be convenient if you have some kind of super key by which you want to generate a pair of RSA keys.